### PR TITLE
Use alloca instead of malloc

### DIFF
--- a/d6.c
+++ b/d6.c
@@ -97,7 +97,7 @@ int main(int argc, char* argv[]) {
 
     // prepare buffer
     const size_t row_len = dice_row_len*count;
-    char* buf = malloc(row_len*7);
+    char* buf = alloca(row_len*7);
     memset(buf, ' ', row_len*7);
 
     // make it rows


### PR DESCRIPTION
This also makes the missing call to `free()` unnecessary.
Resolves #1 and #2.